### PR TITLE
fix: make clean niggles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,3 +167,5 @@ clean:
 	@rm -f $(App_Name) $(RustEnclave_Name) $(Signed_RustEnclave_Name) $(Qpl_Name) enclave/*_t.* app/*_u.* lib/*.a
 	@cd enclave && cargo clean && rm -f Cargo.lock
 	@cd app && cargo clean && rm -f Cargo.lock
+	@rm -df lib
+	@rm -df bin

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ enclave:
 .PHONY: clean
 clean:
 	@rm -f $(App_Name) $(RustEnclave_Name) $(Signed_RustEnclave_Name) $(Qpl_Name) enclave/*_t.* app/*_u.* lib/*.a
-	@cd enclave && cargo clean && rm -f Cargo.lock
-	@cd app && cargo clean && rm -f Cargo.lock
+	@cd enclave && cargo clean
+	@cd app && cargo clean
 	@rm -df lib
 	@rm -df bin


### PR DESCRIPTION
* Stop `make clean` from removing the `Cargo.lock` files. (I assume we want to maintain this in version control.)
* Clean up the created `lib` and `bin` directories, for good measure.