### PR TITLE
build(rtc_data_enclave): fix file target typo

### DIFF
--- a/rtc_data_enclave/Makefile
+++ b/rtc_data_enclave/Makefile
@@ -33,7 +33,7 @@ CUSTOM_BIN_PATH := $(CUSTOM_BUILD_PATH)/bin
 
 Crate_Files := $(wildcard src/*.rs)
 Out_Library := $(CRATE_BUILD_PATH)/lib$(CRATE_LIB_NAME).a
-Out_Bindings := $(CODEGEN_PATH)/bdingins.h
+Out_Bindings := $(CODEGEN_PATH)/bindings.h
 
 Out_EdgeObject := $(CUSTOM_LIBRARY_PATH)/Enclave_t.o
 Out_Dylib := $(CUSTOM_LIBRARY_PATH)/enclave.so


### PR DESCRIPTION
This was causing the bindings to be rebuilt unnecessarily on every `make` invocation.

(Doing a full project rebuild + test with no source changes goes much faster now: 1m10s to 7s here. 🎉)