### PR TITLE
build: fix Makefile variable name: Out_Library → Out_StaticLib

### DIFF
--- a/rtc_auth_enclave/Makefile
+++ b/rtc_auth_enclave/Makefile
@@ -32,7 +32,7 @@ CUSTOM_LIBRARY_PATH := $(CUSTOM_BUILD_PATH)/lib
 CUSTOM_BIN_PATH := $(CUSTOM_BUILD_PATH)/bin
 
 Crate_Files := $(wildcard src/*.rs)
-Out_Library := $(CRATE_BUILD_PATH)/lib$(CRATE_LIB_NAME).a
+Out_StaticLib := $(CRATE_BUILD_PATH)/lib$(CRATE_LIB_NAME).a
 Out_Bindings := $(CODEGEN_PATH)/bindings.h
 
 Out_EdgeObject := $(CUSTOM_LIBRARY_PATH)/Enclave_t.o

--- a/rtc_data_enclave/Makefile
+++ b/rtc_data_enclave/Makefile
@@ -32,7 +32,7 @@ CUSTOM_LIBRARY_PATH := $(CUSTOM_BUILD_PATH)/lib
 CUSTOM_BIN_PATH := $(CUSTOM_BUILD_PATH)/bin
 
 Crate_Files := $(wildcard src/*.rs)
-Out_Library := $(CRATE_BUILD_PATH)/lib$(CRATE_LIB_NAME).a
+Out_StaticLib := $(CRATE_BUILD_PATH)/lib$(CRATE_LIB_NAME).a
 Out_Bindings := $(CODEGEN_PATH)/bindings.h
 
 Out_EdgeObject := $(CUSTOM_LIBRARY_PATH)/Enclave_t.o


### PR DESCRIPTION
This was causing `make` to fail to rebuild `libenclave.a`.