### PR TITLE
Refactor uenclave to support multiple enclaves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,6 @@ dependencies = [
  "bindgen",
  "cc",
  "data-ocalls",
- "mockall",
  "rtc-ecalls",
  "rtc_types",
  "sgx_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "auth-sys"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "cc",
+ "mockall",
+ "rtc-ecalls",
+ "rtc_types",
+ "sgx_types",
+ "sgx_urts",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +629,7 @@ dependencies = [
  "cc",
  "data-ocalls",
  "mockall",
+ "rtc-ecalls",
  "rtc_types",
  "sgx_types",
  "sgx_urts",
@@ -1614,6 +1628,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtc-ecalls"
+version = "0.1.0"
+dependencies = [
+ "mockall",
+ "rtc_types",
+ "sgx_types",
+]
+
+[[package]]
 name = "rtc_data_service"
 version = "0.0.1"
 dependencies = [
@@ -1659,6 +1682,7 @@ dependencies = [
 name = "rtc_uenclave"
 version = "0.1.0"
 dependencies = [
+ "auth-sys",
  "base64",
  "data-sys",
  "mockall",
@@ -1668,6 +1692,7 @@ dependencies = [
  "proptest",
  "rand 0.7.3",
  "rsa",
+ "rtc-ecalls",
  "rtc_types",
  "serde 1.0.125",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,6 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "cc",
- "mockall",
  "rtc-ecalls",
  "rtc_types",
  "sgx_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ members = [
     "rtc_uenclave",
     "rtc_uenclave/data-ocalls",
     "rtc_uenclave/data-sys",
+    "rtc_uenclave/auth-sys",
+    "rtc_uenclave/rtc-ecalls",
 ]
 # TODO: Look at creating a seperate workspace for enclave code to share lockfile?
 exclude = [

--- a/rtc_data_service/src/data_enclave_actor.rs
+++ b/rtc_data_service/src/data_enclave_actor.rs
@@ -1,5 +1,5 @@
 use actix::prelude::*;
-use rtc_uenclave::{AttestationError, EnclaveConfig, RtcEnclave};
+use rtc_uenclave::{AttestationError, EnclaveConfig, RtcDataEnclave};
 use std::sync::Arc;
 
 #[derive(Default)]
@@ -12,7 +12,7 @@ impl Message for RequestAttestation {
 }
 
 pub struct DataEnclaveActor {
-    enclave: Option<RtcEnclave<Arc<EnclaveConfig>>>,
+    enclave: Option<RtcDataEnclave<Arc<EnclaveConfig>>>,
     config: Arc<EnclaveConfig>,
 }
 
@@ -29,7 +29,7 @@ impl DataEnclaveActor {
     /// # Panics
     ///
     /// Panics if the enclave was not initialised.
-    pub(crate) fn get_enclave(&self) -> &RtcEnclave<Arc<EnclaveConfig>> {
+    pub(crate) fn get_enclave(&self) -> &RtcDataEnclave<Arc<EnclaveConfig>> {
         self.enclave
             .as_ref()
             .expect("DataEnclaveActor: tried to access enclave while not initialised")
@@ -51,7 +51,7 @@ impl Actor for DataEnclaveActor {
 
     fn started(&mut self, _ctx: &mut Self::Context) {
         self.enclave
-            .replace(RtcEnclave::init(self.config.clone()).expect("enclave to initialize"));
+            .replace(RtcDataEnclave::init(self.config.clone()).expect("enclave to initialize"));
     }
 }
 
@@ -67,7 +67,7 @@ impl Handler<RequestAttestation> for DataEnclaveActor {
 impl actix::Supervised for DataEnclaveActor {
     fn restarting(&mut self, _ctx: &mut Context<DataEnclaveActor>) {
         self.enclave
-            .replace(RtcEnclave::init(self.config.clone()).expect("enclave to be initialized"))
+            .replace(RtcDataEnclave::init(self.config.clone()).expect("enclave to be initialized"))
             .map(|enc| enc.destroy());
     }
 }

--- a/rtc_data_service/tests/data_upload.rs
+++ b/rtc_data_service/tests/data_upload.rs
@@ -34,7 +34,7 @@ async fn data_service_data_upload_ok() {
 
     // TODO: Add a test that can run inside of the enclave and use the JWT token to get
     // the enclave key
-    let enclave = rtc_uenclave::RtcEnclave::init(EnclaveConfig {
+    let enclave = rtc_uenclave::RtcDataEnclave::init(EnclaveConfig {
         lib_path: "/root/rtc-data/rtc_data_enclave/build/bin/enclave.signed.so".to_string(),
         ..Default::default()
     })

--- a/rtc_uenclave/Cargo.toml
+++ b/rtc_uenclave/Cargo.toml
@@ -6,6 +6,12 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["data_enclave", "auth_enclave"]
+data_enclave = ["data-sys"]
+auth_enclave = ["auth-sys"]
+
+
 [dependencies]
 sgx_types = { git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["extra_traits"] }
 sgx_urts = { git = "https://github.com/apache/teaclave-sgx-sdk.git", rev = "v1.1.3" }
@@ -17,7 +23,9 @@ rtc_types = {path = "../rtc_types"}
 serde = { version = "1.0.125", features = ["derive"] }
 ureq = { version = "2.1.0", features = ["json"] }
 serde_json = "1.0.64"
-data-sys = { path = "./data-sys" }
+data-sys = { path = "./data-sys", optional = true }
+auth-sys = { path = "./auth-sys", optional = true }
+rtc-ecalls = { path = "./rtc-ecalls" }
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/rtc_uenclave/auth-sys/Cargo.toml
+++ b/rtc_uenclave/auth-sys/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
-name = "data-sys"
+name = "auth-sys"
 version = "0.1.0"
 authors = ["Herman <herman@registree.io>"]
 edition = "2018"
-links = "Enclave_u"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,8 +10,7 @@ links = "Enclave_u"
 sgx_types = { git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["extra_traits"] }
 sgx_urts = { git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 rtc_types = { path = "../../rtc_types" }
-data-ocalls = { path = "../data-ocalls" }
-# TODO: Move this to a seperate feature?
+
 mockall = { version = "0.9.1", features = ["nightly"] }
 rtc-ecalls = { path = "../rtc-ecalls" }
 

--- a/rtc_uenclave/auth-sys/Cargo.toml
+++ b/rtc_uenclave/auth-sys/Cargo.toml
@@ -10,8 +10,6 @@ edition = "2018"
 sgx_types = { git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["extra_traits"] }
 sgx_urts = { git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 rtc_types = { path = "../../rtc_types" }
-
-mockall = { version = "0.9.1", features = ["nightly"] }
 rtc-ecalls = { path = "../rtc-ecalls" }
 
 [build-dependencies]

--- a/rtc_uenclave/auth-sys/build.rs
+++ b/rtc_uenclave/auth-sys/build.rs
@@ -6,7 +6,7 @@ use std::{env, path::Path};
 fn main() {
     let sdk_dir = env::var("SGX_SDK").unwrap_or_else(|_| "/opt/sgxsdk".to_string());
     let profile = env::var("PROFILE").unwrap();
-    let enclave_gen = Path::new("../../codegen/data_enclave");
+    let enclave_gen = Path::new("../../codegen/auth_enclave");
 
     let includes = vec![
         format!("{}/include", sdk_dir),
@@ -54,7 +54,6 @@ fn main() {
         .array_pointers_in_arguments(true)
         // TODO: see if there is a way to include functions using globbing
         .allowlist_function("enclave_create_report")
-        .allowlist_function("rtc_validate_and_save")
         .clang_args(&inc_args)
         .generate()
         .expect("Unable to generate bindings")

--- a/rtc_uenclave/auth-sys/build.rs
+++ b/rtc_uenclave/auth-sys/build.rs
@@ -58,5 +58,5 @@ fn main() {
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file(out_path.join("bindings.rs"))
-        .expect("Failed to wirte bindings to file");
+        .expect("Failed to write bindings to file");
 }

--- a/rtc_uenclave/auth-sys/src/lib.rs
+++ b/rtc_uenclave/auth-sys/src/lib.rs
@@ -1,19 +1,12 @@
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-
-use data_ocalls;
 use rtc_ecalls::RtcEnclaveEcalls;
 use rtc_types::*;
 use sgx_types::*;
 use sgx_urts;
 
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-
 #[derive(Default)]
-pub struct DataSys();
+pub struct AuthSys();
 
-impl RtcEnclaveEcalls for DataSys {
+impl RtcEnclaveEcalls for AuthSys {
     unsafe fn enclave_create_report(
         &self,
         eid: sgx_enclave_id_t,
@@ -22,6 +15,6 @@ impl RtcEnclaveEcalls for DataSys {
         enclave_data: *mut EnclaveHeldData,
         p_report: *mut sgx_report_t,
     ) -> sgx_status_t {
-        ffi::enclave_create_report(eid, retval, p_qe3_target, enclave_data, p_report)
+        todo!();
     }
 }

--- a/rtc_uenclave/auth-sys/src/lib.rs
+++ b/rtc_uenclave/auth-sys/src/lib.rs
@@ -1,7 +1,14 @@
+#[allow(unused_imports)]
+use sgx_urts;
+
 use rtc_ecalls::RtcEnclaveEcalls;
 use rtc_types::*;
 use sgx_types::*;
-use sgx_urts;
+
+pub mod ffi {
+    use super::*;
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
 
 #[derive(Default)]
 pub struct AuthSys();
@@ -15,6 +22,6 @@ impl RtcEnclaveEcalls for AuthSys {
         enclave_data: *mut EnclaveHeldData,
         p_report: *mut sgx_report_t,
     ) -> sgx_status_t {
-        todo!();
+        ffi::enclave_create_report(eid, retval, p_qe3_target, enclave_data, p_report)
     }
 }

--- a/rtc_uenclave/auth-sys/wrapper.h
+++ b/rtc_uenclave/auth-sys/wrapper.h
@@ -1,0 +1,1 @@
+#include "../../codegen/auth_enclave/Enclave_u.h"

--- a/rtc_uenclave/data-sys/Cargo.toml
+++ b/rtc_uenclave/data-sys/Cargo.toml
@@ -12,8 +12,6 @@ sgx_types = { git = "https://github.com/apache/teaclave-sgx-sdk.git", features =
 sgx_urts = { git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 rtc_types = { path = "../../rtc_types" }
 data-ocalls = { path = "../data-ocalls" }
-# TODO: Move this to a seperate feature?
-mockall = { version = "0.9.1", features = ["nightly"] }
 rtc-ecalls = { path = "../rtc-ecalls" }
 
 [build-dependencies]

--- a/rtc_uenclave/data-sys/build.rs
+++ b/rtc_uenclave/data-sys/build.rs
@@ -43,7 +43,8 @@ fn main() {
         .flat_map(|x| vec!["-I", x.as_str()])
         .collect();
 
-    let bindings = bindgen::Builder::default()
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindgen::Builder::default()
         .header("wrapper.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
@@ -57,16 +58,6 @@ fn main() {
         .clang_args(&inc_args)
         .generate()
         .expect("Unable to generate bindings")
-        .to_string();
-
-    let mut bindings_string = "use mockall::automock;\n".to_owned();
-
-    bindings_string.push_str("#[automock]\npub mod ffi {\nuse super::*;\n");
-    bindings_string.push_str(&bindings);
-    bindings_string.push_str("}\n");
-
-    // Write the bindings to the $OUT_DIR/bindings.rs file.
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    std::fs::write(out_path.join("bindings.rs"), bindings_string.as_bytes())
-        .expect("Failed to save bindings");
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Failed to wirte bindings to file");
 }

--- a/rtc_uenclave/data-sys/src/lib.rs
+++ b/rtc_uenclave/data-sys/src/lib.rs
@@ -8,7 +8,10 @@ use rtc_types::*;
 use sgx_types::*;
 use sgx_urts;
 
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+pub mod ffi {
+    use super::*;
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
 
 #[derive(Default)]
 pub struct DataSys();

--- a/rtc_uenclave/data-sys/src/lib.rs
+++ b/rtc_uenclave/data-sys/src/lib.rs
@@ -2,11 +2,14 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+#[allow(unused_imports)]
 use data_ocalls;
+#[allow(unused_imports)]
+use sgx_urts;
+
 use rtc_ecalls::RtcEnclaveEcalls;
 use rtc_types::*;
 use sgx_types::*;
-use sgx_urts;
 
 pub mod ffi {
     use super::*;

--- a/rtc_uenclave/rtc-ecalls/Cargo.toml
+++ b/rtc_uenclave/rtc-ecalls/Cargo.toml
@@ -1,21 +1,12 @@
 [package]
-name = "data-sys"
+name = "rtc-ecalls"
 version = "0.1.0"
 authors = ["Herman <herman@registree.io>"]
 edition = "2018"
-links = "Enclave_u"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 sgx_types = { git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["extra_traits"] }
-sgx_urts = { git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 rtc_types = { path = "../../rtc_types" }
-data-ocalls = { path = "../data-ocalls" }
-# TODO: Move this to a seperate feature?
 mockall = { version = "0.9.1", features = ["nightly"] }
-rtc-ecalls = { path = "../rtc-ecalls" }
-
-[build-dependencies]
-cc = "1.0.67"
-bindgen = "0.58.1"

--- a/rtc_uenclave/rtc-ecalls/src/lib.rs
+++ b/rtc_uenclave/rtc-ecalls/src/lib.rs
@@ -1,0 +1,15 @@
+use mockall::automock;
+use rtc_types::*;
+use sgx_types::*;
+
+#[automock]
+pub trait RtcEnclaveEcalls: Default {
+    unsafe fn enclave_create_report(
+        &self,
+        eid: sgx_enclave_id_t,
+        retval: *mut CreateReportResult,
+        p_qe3_target: *const sgx_target_info_t,
+        enclave_data: *mut EnclaveHeldData,
+        p_report: *mut sgx_report_t,
+    ) -> sgx_status_t;
+}

--- a/rtc_uenclave/src/enclaves/mod.rs
+++ b/rtc_uenclave/src/enclaves/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "auth_enclave")]
+mod rtc_auth;
+#[cfg(feature = "data_enclave")]
+mod rtc_data;
+
+#[cfg(feature = "auth_enclave")]
+pub use self::rtc_auth::*;
+#[cfg(feature = "data_enclave")]
+pub use self::rtc_data::*;

--- a/rtc_uenclave/src/enclaves/rtc_auth.rs
+++ b/rtc_uenclave/src/enclaves/rtc_auth.rs
@@ -5,6 +5,7 @@ use sgx_types::*;
 
 use crate::{AttestationError, EnclaveConfig, EnclaveReportResult, RtcEnclave};
 
+/// Wraps all the functionality for interacting with the auth enclave
 pub struct RtcAuthEnclave<TCfg>(RtcEnclave<TCfg, AuthSys>)
 where
     TCfg: Borrow<EnclaveConfig>;
@@ -13,10 +14,12 @@ impl<TCfg> RtcAuthEnclave<TCfg>
 where
     TCfg: Borrow<EnclaveConfig>,
 {
+    /// Creates a new enclave instance with the provided configuration
     pub fn init(cfg: TCfg) -> Result<Self, sgx_status_t> {
         Ok(Self(RtcEnclave::init(cfg)?))
     }
 
+    /// Creates a report and signed enclave held data for the enclave
     pub fn create_report(
         &self,
         qe_target_info: &sgx_target_info_t,
@@ -24,6 +27,9 @@ where
         self.0.create_report(qe_target_info)
     }
 
+    /// Performs dcap attestation using Azure Attestation
+    ///
+    /// Returns the JWT token with the quote and enclave data
     pub fn dcap_attestation_azure(&self) -> Result<String, AttestationError> {
         self.0.dcap_attestation_azure()
     }

--- a/rtc_uenclave/src/enclaves/rtc_auth.rs
+++ b/rtc_uenclave/src/enclaves/rtc_auth.rs
@@ -1,0 +1,40 @@
+use std::borrow::Borrow;
+
+use auth_sys::AuthSys;
+use sgx_types::*;
+
+use crate::{AttestationError, EnclaveConfig, EnclaveReportResult, RtcEnclave};
+
+pub struct RtcAuthEnclave<TCfg>(RtcEnclave<TCfg, AuthSys>)
+where
+    TCfg: Borrow<EnclaveConfig>;
+
+impl<TCfg> RtcAuthEnclave<TCfg>
+where
+    TCfg: Borrow<EnclaveConfig>,
+{
+    pub fn init(cfg: TCfg) -> Result<Self, sgx_status_t> {
+        Ok(Self(RtcEnclave::init(cfg)?))
+    }
+
+    pub fn create_report(
+        &self,
+        qe_target_info: &sgx_target_info_t,
+    ) -> Result<EnclaveReportResult, AttestationError> {
+        self.0.create_report(qe_target_info)
+    }
+
+    pub fn dcap_attestation_azure(&self) -> Result<String, AttestationError> {
+        self.0.dcap_attestation_azure()
+    }
+
+    /// Take ownership of self and drop resources
+    pub fn destroy(self) {
+        // Take ownership of self and drop
+    }
+
+    /// `true` if the enclave have been initialized
+    pub fn is_initialized(&self) -> bool {
+        self.0.is_initialized()
+    }
+}

--- a/rtc_uenclave/src/enclaves/rtc_data.rs
+++ b/rtc_uenclave/src/enclaves/rtc_data.rs
@@ -1,0 +1,68 @@
+use std::borrow::Borrow;
+
+use data_sys::DataSys;
+use rtc_types::*;
+use sgx_types::*;
+
+use crate::{AttestationError, EnclaveConfig, EnclaveReportResult, RtcEnclave};
+
+pub struct RtcDataEnclave<TCfg>(RtcEnclave<TCfg, DataSys>)
+where
+    TCfg: Borrow<EnclaveConfig>;
+
+impl<TCfg> RtcDataEnclave<TCfg>
+where
+    TCfg: Borrow<EnclaveConfig>,
+{
+    pub fn init(cfg: TCfg) -> Result<Self, sgx_status_t> {
+        Ok(Self(RtcEnclave::init(cfg)?))
+    }
+
+    pub fn create_report(
+        &self,
+        qe_target_info: &sgx_target_info_t,
+    ) -> Result<EnclaveReportResult, AttestationError> {
+        self.0.create_report(qe_target_info)
+    }
+
+    pub fn dcap_attestation_azure(&self) -> Result<String, AttestationError> {
+        self.0.dcap_attestation_azure()
+    }
+
+    pub fn upload_data(
+        &self,
+        payload: &[u8],
+        metadata: UploadMetadata,
+    ) -> Result<DataUploadResponse, EcallError<DataUploadError>> {
+        ecalls::validate_and_save(self.0.geteid(), payload, metadata)
+    }
+
+    /// Take ownership of self and drop resources
+    pub fn destroy(self) {
+        // Take ownership of self and drop
+    }
+
+    /// `true` if the enclave have been initialized
+    pub fn is_initialized(&self) -> bool {
+        self.0.is_initialized()
+    }
+}
+
+pub mod ecalls {
+    use data_sys::ffi;
+    use rtc_types::*;
+    use sgx_types::*;
+
+    pub fn validate_and_save(
+        eid: sgx_enclave_id_t,
+        payload: &[u8],
+        metadata: UploadMetadata,
+    ) -> Result<DataUploadResponse, EcallError<DataUploadError>> {
+        let mut retval = DataUploadResult::default();
+        // TODO: Safety
+        let res = unsafe {
+            ffi::rtc_validate_and_save(eid, &mut retval, payload.as_ptr(), payload.len(), metadata)
+        };
+        retval.to_ecall_err(res).into()
+    }
+}

--- a/rtc_uenclave/src/enclaves/rtc_data.rs
+++ b/rtc_uenclave/src/enclaves/rtc_data.rs
@@ -6,6 +6,7 @@ use sgx_types::*;
 
 use crate::{AttestationError, EnclaveConfig, EnclaveReportResult, RtcEnclave};
 
+/// Wraps all the functionality for interacting with the data enclave
 pub struct RtcDataEnclave<TCfg>(RtcEnclave<TCfg, DataSys>)
 where
     TCfg: Borrow<EnclaveConfig>;
@@ -14,10 +15,12 @@ impl<TCfg> RtcDataEnclave<TCfg>
 where
     TCfg: Borrow<EnclaveConfig>,
 {
+    /// Creates a new enclave instance with the provided configuration
     pub fn init(cfg: TCfg) -> Result<Self, sgx_status_t> {
         Ok(Self(RtcEnclave::init(cfg)?))
     }
 
+    /// Creates a report and signed enclave held data
     pub fn create_report(
         &self,
         qe_target_info: &sgx_target_info_t,
@@ -25,10 +28,17 @@ where
         self.0.create_report(qe_target_info)
     }
 
+    /// Performs dcap attestation using Azure Attestation
+    ///
+    /// Returns the JWT token with the quote and enclave data
     pub fn dcap_attestation_azure(&self) -> Result<String, AttestationError> {
         self.0.dcap_attestation_azure()
     }
 
+    /// Decrypts, seal and save upload data inside of the enclave
+    ///
+    /// Returns an encrypted payload with the UUID and access-key for
+    /// uploaded data
     pub fn upload_data(
         &self,
         payload: &[u8],

--- a/rtc_uenclave/src/enclaves/rtc_data.rs
+++ b/rtc_uenclave/src/enclaves/rtc_data.rs
@@ -47,6 +47,14 @@ where
         ecalls::validate_and_save(self.0.geteid(), payload, metadata)
     }
 
+    pub fn get_exec_token(&self) -> Result<ExecTokenResponse, ExecTokenError> {
+        // TODO: Placeholder response
+        Ok(ExecTokenResponse {
+            execution_token: vec![128; 9],
+            nonce: [7; 24],
+        })
+    }
+
     /// Take ownership of self and drop resources
     pub fn destroy(self) {
         // Take ownership of self and drop

--- a/rtc_uenclave/src/lib.rs
+++ b/rtc_uenclave/src/lib.rs
@@ -1,7 +1,6 @@
 //! Base library used to interact with an rtc_enclave from a non-sgx environment
 #![cfg_attr(test, allow(unused))]
 #![deny(clippy::mem_forget)]
-#![feature(unsafe_block_in_unsafe_fn)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![feature(toowned_clone_into)]
 #![warn(missing_docs)]

--- a/rtc_uenclave/src/lib.rs
+++ b/rtc_uenclave/src/lib.rs
@@ -8,9 +8,11 @@
 
 mod azure_attestation;
 mod ecalls;
+mod enclaves;
 mod http_client;
 mod quote;
 mod rtc_enclave;
 
 pub use ecalls::{CreateReportError, EnclaveReportResult};
+pub use enclaves::*;
 pub use rtc_enclave::*;

--- a/rtc_uenclave/src/lib.rs
+++ b/rtc_uenclave/src/lib.rs
@@ -1,4 +1,5 @@
 //! Base library used to interact with an rtc_enclave from a non-sgx environment
+#![cfg_attr(test, allow(unused))]
 #![deny(clippy::mem_forget)]
 #![feature(unsafe_block_in_unsafe_fn)]
 #![deny(unsafe_op_in_unsafe_fn)]

--- a/rtc_uenclave/src/rtc_enclave.rs
+++ b/rtc_uenclave/src/rtc_enclave.rs
@@ -137,14 +137,6 @@ impl<TCfg: Borrow<EnclaveConfig>, TEcalls: RtcEcalls> RtcEnclave<TCfg, TEcalls> 
     pub fn geteid(&self) -> sgx_enclave_id_t {
         self.base_enclave.geteid()
     }
-
-    pub fn get_exec_token(&self) -> Result<ExecTokenResponse, ExecTokenError> {
-        // TODO: Placeholder response
-        Ok(ExecTokenResponse {
-            execution_token: vec![128; 9],
-            nonce: [7; 24],
-        })
-    }
 }
 
 /// Attestation process failed

--- a/rtc_uenclave/src/rtc_enclave.rs
+++ b/rtc_uenclave/src/rtc_enclave.rs
@@ -138,12 +138,6 @@ impl<TCfg: Borrow<EnclaveConfig>, TEcalls: RtcEcalls> RtcEnclave<TCfg, TEcalls> 
         self.base_enclave.geteid()
     }
 
-    /// Take ownership of self and drop resources
-    pub fn destroy(self) {
-        println!("Destroying Enclave");
-        // Take ownership of self and drop
-    }
-
     pub fn get_exec_token(&self) -> Result<ExecTokenResponse, ExecTokenError> {
         // TODO: Placeholder response
         Ok(ExecTokenResponse {


### PR DESCRIPTION
Depends on: #55 
- [x] Setup bindgen for auth-sys
 - [x] Check if the mock codegen is still needed for data-sys