### PR TITLE
build(rtc_auth_enclave): add Crate_Files dependency on rtc_tenclave source

### DIFF
--- a/rtc_auth_enclave/Makefile
+++ b/rtc_auth_enclave/Makefile
@@ -31,7 +31,8 @@ CUSTOM_BUILD_PATH := build
 CUSTOM_LIBRARY_PATH := $(CUSTOM_BUILD_PATH)/lib
 CUSTOM_BIN_PATH := $(CUSTOM_BUILD_PATH)/bin
 
-Crate_Files := $(wildcard src/*.rs)
+# XXX: Is there a better way to express this source dependency on rtc_tenclave?
+Crate_Files := $(wildcard src/*.rs ../rtc_tenclave/src/*.rs)
 Out_StaticLib := $(CRATE_BUILD_PATH)/lib$(CRATE_LIB_NAME).a
 Out_Bindings := $(CODEGEN_PATH)/bindings.h
 


### PR DESCRIPTION
This applies the #58 fix to the auth enclave.

(Closes #62)