### PR TITLE
address cargo check ✨ and enable cargo fix 🎉 

### DIFF
--- a/rtc_auth_enclave/src/lib.rs
+++ b/rtc_auth_enclave/src/lib.rs
@@ -4,7 +4,6 @@
 #![deny(clippy::mem_forget)]
 
 #[cfg(not(target_env = "sgx"))]
-#[macro_use]
 extern crate sgx_tstd as std;
 
 pub use rtc_tenclave::dh::*;

--- a/rtc_auth_enclave/src/lib.rs
+++ b/rtc_auth_enclave/src/lib.rs
@@ -9,4 +9,5 @@
 extern crate sgx_tstd as std;
 
 pub use rtc_tenclave::dh::*;
-pub use rtc_tenclave::enclave::*;
+#[allow(unused_imports)] // for ECALL linking
+use rtc_tenclave::enclave::enclave_create_report;

--- a/rtc_auth_enclave/src/lib.rs
+++ b/rtc_auth_enclave/src/lib.rs
@@ -1,6 +1,5 @@
 #![crate_type = "staticlib"]
 #![no_std]
-#![feature(unsafe_block_in_unsafe_fn)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(clippy::mem_forget)]
 

--- a/rtc_data_enclave/src/data_upload.rs
+++ b/rtc_data_enclave/src/data_upload.rs
@@ -1,16 +1,14 @@
-use core::convert::TryInto;
 use rand::prelude::*;
 use rtc_tenclave::crypto::RtcCrypto;
 use rtc_tenclave::crypto::SodaBoxCrypto as Crypto;
 use rtc_tenclave::util;
+use rtc_types::DataUploadError as DataError;
 use rtc_types::UploadMetadata as Metadata;
-use rtc_types::{CryptoError, DataUploadResponse, EncryptedMessage};
-use rtc_types::{DataUploadError as DataError, SizedEncryptedMessage};
-use secrecy::{ExposeSecret, Secret, Zeroize};
+use rtc_types::{CryptoError, DataUploadResponse};
+use secrecy::{ExposeSecret, Zeroize};
 use sgx_tseal::SgxSealedData;
 use sgx_types::*;
 use std::prelude::v1::*;
-use thiserror::Error;
 use uuid::Uuid;
 
 pub struct SealedResult {

--- a/rtc_data_enclave/src/data_upload.rs
+++ b/rtc_data_enclave/src/data_upload.rs
@@ -56,7 +56,7 @@ fn generate_client_payload(
         Err(err) => return Err(CryptoError::Rand(err.code().map_or(0, |code| code.get()))),
     };
 
-    let mut message = util::concat_u8(&pass, uuid.as_bytes());
+    let message = util::concat_u8(&pass, uuid.as_bytes());
 
     pass.zeroize();
 

--- a/rtc_data_enclave/src/lib.rs
+++ b/rtc_data_enclave/src/lib.rs
@@ -45,8 +45,8 @@ pub unsafe extern "C" fn validate_and_save(
     };
 
     match ocalls::save_sealed_blob_u(sealed.sealed_data, sealed.uuid) {
-        (sgx_status_t::SGX_SUCCESS) => EcallResult::Ok(sealed.client_payload.into()),
-        (err) => EcallResult::Err(DataUploadError::Sealing(err)),
+        sgx_status_t::SGX_SUCCESS => EcallResult::Ok(sealed.client_payload.into()),
+        err => EcallResult::Err(DataUploadError::Sealing(err)),
     }
 }
 

--- a/rtc_data_enclave/src/lib.rs
+++ b/rtc_data_enclave/src/lib.rs
@@ -9,25 +9,18 @@
 // TODO: Clean up existing cases causing a flood of warnings for this check, and re-enable
 // #![warn(missing_docs)]
 
-use rtc_tenclave::crypto::{RtcCrypto, SodaBoxCrypto};
 use sgx_types;
 #[cfg(not(target_env = "sgx"))]
 #[macro_use]
 extern crate sgx_tstd as std;
-use sgx_tcrypto;
-use sgx_tse;
 
 mod data_upload;
 mod ocalls;
 
 use core::slice;
 use rtc_types::*;
-use sgx_tse::rsgx_create_report;
 use sgx_types::*;
 use std::prelude::v1::*;
-
-use sgx_tcrypto::rsgx_sha256_slice;
-use zeroize::Zeroize;
 
 #[allow(unused_imports)] // for ECALL linking
 use rtc_tenclave::enclave::enclave_create_report;

--- a/rtc_data_enclave/src/lib.rs
+++ b/rtc_data_enclave/src/lib.rs
@@ -29,7 +29,8 @@ use std::prelude::v1::*;
 use sgx_tcrypto::rsgx_sha256_slice;
 use zeroize::Zeroize;
 
-use rtc_tenclave::enclave::*;
+#[allow(unused_imports)] // for ECALL linking
+use rtc_tenclave::enclave::enclave_create_report;
 
 /// Validates and save a payload encrypted for the enclave
 ///

--- a/rtc_data_enclave/src/lib.rs
+++ b/rtc_data_enclave/src/lib.rs
@@ -3,8 +3,6 @@
 #![crate_type = "staticlib"]
 #![cfg_attr(not(target_env = "sgx"), no_std)]
 #![cfg_attr(target_env = "sgx", feature(rustc_private))]
-#![feature(const_generics)]
-#![feature(const_evaluatable_checked)]
 #![deny(clippy::mem_forget)]
 // TODO: Clean up existing cases causing a flood of warnings for this check, and re-enable
 // #![warn(missing_docs)]

--- a/rtc_data_enclave/src/lib.rs
+++ b/rtc_data_enclave/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(unsafe_block_in_unsafe_fn)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![crate_type = "staticlib"]
 #![cfg_attr(not(target_env = "sgx"), no_std)]

--- a/rtc_data_service/build.rs
+++ b/rtc_data_service/build.rs
@@ -1,4 +1,3 @@
-use cc;
 use std::env;
 use std::process::Command;
 fn main() {

--- a/rtc_data_service/build.rs
+++ b/rtc_data_service/build.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::process::Command;
 fn main() {
     let sdk_dir = env::var("SGX_SDK").unwrap_or_else(|_| "/opt/sgxsdk".to_string());
-    let profile = env::var("PROFILE").unwrap();
+    let _profile = env::var("PROFILE").unwrap();
     let is_sim = env::var("SGX_MODE").unwrap_or_else(|_| "HW".to_string());
 
     println!("cargo:rerun-if-env-changed=SGX_MODE");

--- a/rtc_data_service/http_server/build.rs
+++ b/rtc_data_service/http_server/build.rs
@@ -2,13 +2,13 @@ use cc;
 use std::env;
 
 fn main() {
-    let test_enabled = env::var_os("CARGO_FEATURE_TEST").is_some();
+    let _test_enabled = env::var_os("CARGO_FEATURE_TEST").is_some();
 
-    let cur_dir = env::current_dir().unwrap();
+    let _cur_dir = env::current_dir().unwrap();
 
     let sdk_dir = env::var("SGX_SDK").unwrap_or_else(|_| "/opt/sgxsdk".to_string());
     let is_sim = env::var("SGX_MODE").unwrap_or_else(|_| "HW".to_string());
-    let profile = env::var("PROFILE").unwrap();
+    let _profile = env::var("PROFILE").unwrap();
 
     println!("cargo:rerun-if-env-changed=SGX_MODE");
 

--- a/rtc_data_service/http_server/build.rs
+++ b/rtc_data_service/http_server/build.rs
@@ -1,4 +1,3 @@
-use cc;
 use std::env;
 
 fn main() {

--- a/rtc_data_service/http_server/src/main.rs
+++ b/rtc_data_service/http_server/src/main.rs
@@ -11,11 +11,7 @@ use rtc_data_service::data_enclave_actor::DataEnclaveActor;
 use rtc_data_service::data_upload::*;
 use rtc_data_service::exec_token::*;
 use rtc_data_service::handlers::*;
-use rtc_data_service::merge_error;
-use rustls::{AllowAnyAuthenticatedClient, NoClientAuth, RootCertStore, ServerConfig};
 
-use std::fs::File;
-use std::io::BufReader;
 use std::sync::Arc;
 
 use actix::{Arbiter, Supervisor};

--- a/rtc_data_service/http_server/src/tls.rs
+++ b/rtc_data_service/http_server/src/tls.rs
@@ -14,7 +14,6 @@ use std::{fs, io};
 pub fn get_tls_server_config(config: TlsConfig) -> Result<TlsServerConfig, TlsConfigError> {
     let client_auth = match config.client_cert_path {
         Some(path) => {
-            let f = fs::File::open(&path)?;
             let mut roots = load_certs(&path)?;
             let mut client_auth_roots = RootCertStore::empty();
             for root in roots {

--- a/rtc_data_service/http_server/src/tls.rs
+++ b/rtc_data_service/http_server/src/tls.rs
@@ -8,7 +8,6 @@ use thiserror::Error;
 
 use std::io::BufReader;
 use std::iter;
-use std::sync::Arc;
 use std::{fs, io};
 
 pub fn get_tls_server_config(config: TlsConfig) -> Result<TlsServerConfig, TlsConfigError> {

--- a/rtc_data_service/http_server/src/tls.rs
+++ b/rtc_data_service/http_server/src/tls.rs
@@ -13,7 +13,7 @@ use std::{fs, io};
 pub fn get_tls_server_config(config: TlsConfig) -> Result<TlsServerConfig, TlsConfigError> {
     let client_auth = match config.client_cert_path {
         Some(path) => {
-            let mut roots = load_certs(&path)?;
+            let roots = load_certs(&path)?;
             let mut client_auth_roots = RootCertStore::empty();
             for root in roots {
                 client_auth_roots.add(&root)?;

--- a/rtc_data_service/src/app_config.rs
+++ b/rtc_data_service/src/app_config.rs
@@ -2,7 +2,6 @@ use config::{Config, ConfigError, Environment, File};
 use rtc_uenclave::EnclaveConfig;
 use serde::Deserialize;
 use std::env;
-use std::path::Path;
 
 // Configuration specific to the server
 #[derive(Deserialize, Clone, Default)]

--- a/rtc_data_service/src/data_upload/message.rs
+++ b/rtc_data_service/src/data_upload/message.rs
@@ -11,7 +11,7 @@ impl Message for DataUploadMessage {
     type Result = Result<DataUploadResponse, EcallError<DataUploadError>>;
 }
 
-/// Handle upload using [`rtc_uenclave::RtcEnclave::upload_data`].
+/// Handle upload using [`rtc_uenclave::RtcDataEnclave::upload_data`].
 impl Handler<DataUploadMessage> for DataEnclaveActor {
     type Result = <DataUploadMessage as Message>::Result;
 

--- a/rtc_data_service/tests/server.rs
+++ b/rtc_data_service/tests/server.rs
@@ -1,18 +1,10 @@
 use actix::Actor;
-use actix_web::{
-    http,
-    test::{self, read_body},
-    App,
-};
-use base64;
+use actix_web::{test, test::read_body, App};
 use insta;
 use rtc_data_service::auth_enclave_actor::AuthEnclaveActor;
 use rtc_data_service::data_enclave_actor::DataEnclaveActor;
 use rtc_data_service::handlers::*;
-use rtc_types::{DataUploadResponse, UploadMetadata};
 use rtc_uenclave::EnclaveConfig;
-use sgx_types::sgx_target_info_t;
-use sodalite;
 
 use std::sync::Arc;
 

--- a/rtc_tenclave/src/dh/sessions.rs
+++ b/rtc_tenclave/src/dh/sessions.rs
@@ -149,7 +149,7 @@ where
 
     /// Attest and establish a new active session between this enclave and `dest_enclave_id`.
     ///
-    /// The responding enclave must be registered using [`rtc_udh::set_responder`].
+    /// The responding enclave must be registered using `rtc_udh::set_responder`.
     pub fn establish_new(
         &self,
         dest_enclave_id: sgx_enclave_id_t,

--- a/rtc_tenclave/src/dh/sessions.rs
+++ b/rtc_tenclave/src/dh/sessions.rs
@@ -270,6 +270,7 @@ pub unsafe extern "C" fn exchange_report(
 }
 
 // TODO: Integrate using function reference with similar signature or a config obj
+#[allow(dead_code)] // not used yet, but will be
 fn verify_peer_enclave_trust(peer_identity: &sgx_dh_session_enclave_identity_t) -> Result<(), ()> {
     let required_flags = SGX_FLAGS_INITTED;
     let denied_flags = SGX_FLAGS_DEBUG;

--- a/rtc_tenclave/src/dh/types.rs
+++ b/rtc_tenclave/src/dh/types.rs
@@ -23,6 +23,7 @@ impl Zeroize for AlignedKey {
 
 pub struct DhValues {
     pub(crate) session_key: Secret<AlignedKey>,
+    #[allow(dead_code)] // not used yet, but will be
     pub(crate) peer_identity: sgx_dh_session_enclave_identity_t,
 }
 

--- a/rtc_tenclave/src/kv_store/fs/std_filer.rs
+++ b/rtc_tenclave/src/kv_store/fs/std_filer.rs
@@ -1,4 +1,4 @@
-//! [`std::fs::File`] support
+//! [`File`] support
 
 use std::prelude::v1::Vec;
 

--- a/rtc_tenclave/src/lib.rs
+++ b/rtc_tenclave/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(unsafe_block_in_unsafe_fn)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(target_env = "sgx", feature(rustc_private))]
 #![allow(incomplete_features)]

--- a/rtc_uenclave/data-sys/src/lib.rs
+++ b/rtc_uenclave/data-sys/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)] // These imports are for the generated bindings.rs
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/rtc_uenclave/src/enclaves/rtc_data.rs
+++ b/rtc_uenclave/src/enclaves/rtc_data.rs
@@ -47,6 +47,7 @@ where
         ecalls::validate_and_save(self.0.geteid(), payload, metadata)
     }
 
+    /// Issue a new execution token.
     pub fn get_exec_token(&self) -> Result<ExecTokenResponse, ExecTokenError> {
         // TODO: Placeholder response
         Ok(ExecTokenResponse {

--- a/rtc_uenclave/src/rtc_enclave.rs
+++ b/rtc_uenclave/src/rtc_enclave.rs
@@ -41,7 +41,7 @@ pub struct EnclaveConfig {
     /// the virtual machine
     ///
     /// For as list of shared providers per region, see:
-    /// https://docs.microsoft.com/en-us/azure/attestation/basic-concepts#regional-shared-provider
+    /// <https://docs.microsoft.com/en-us/azure/attestation/basic-concepts#regional-shared-provider>
     pub attestation_provider_url: String,
 
     /// `true` to run the enclave in debug mode (INSECURE).


### PR DESCRIPTION
These changes are not high priority, but I've been accumulating them on the side, until `cargo check` passes cleanly in this branch.

The main functional change is to mark all the `use` imports that have side effects for enclave linking: this means that we can now use `cargo fix` without breaking the build!