### PR TITLE
build: better Makefile crate dependency definitions

### DIFF
--- a/rtc_auth_enclave/Makefile
+++ b/rtc_auth_enclave/Makefile
@@ -32,8 +32,10 @@ CUSTOM_BUILD_PATH := build
 CUSTOM_LIBRARY_PATH := $(CUSTOM_BUILD_PATH)/lib
 CUSTOM_BIN_PATH := $(CUSTOM_BUILD_PATH)/bin
 
-# XXX: Is there a better way to express this source dependency on rtc_tenclave?
-Crate_Files := $(wildcard src/*.rs ../rtc_tenclave/src/*.rs)
+# Changes to these files trigger a rebuild of the enclave library (Out_StaticLib).
+# This includes the Rust source files of this crate, as well as the workspace crates we depend on.
+Crate_Files := $(shell find src ../rtc_tenclave/src ../rtc_types/src -name '*.rs')
+
 Out_StaticLib := $(CRATE_BUILD_PATH)/lib$(CRATE_LIB_NAME).a
 Out_Bindings := $(CODEGEN_PATH)/bindings.h
 

--- a/rtc_auth_enclave/Makefile
+++ b/rtc_auth_enclave/Makefile
@@ -86,17 +86,18 @@ $(CODEGEN_PATH):
 	mkdir -p $(CODEGEN_PATH)
 
 ####### Enclave Build ########
+#
+# XXX: Make sure cargo build refreshes the output files when this rule executes.
+#
+# Currently, it's possible for make to consider the output files out of date,
+# while cargo considers the build up to date, because cargo resolves with more nuance
+# than the crude wildcard function in Crate_Files. When this happens, make gets stuck
+# trying to re-run this rule, without cargo touching the output files.
+#
+# To avoid this edge case, remove the two output files before invoking cargo build.
+# This ensures that cargo build recreates them, with timestamps that satisfy make.
+#
 $(Out_StaticLib) $(Out_Bindings): $(Crate_Files)
-	# XXX: Make sure cargo build refreshes the output files when this rule executes.
-	#
-	# Currently, it's possible for make to consider the output files out of date,
-	# while cargo considers the build up to date, because cargo resolves with more nuance
-	# than the crude wildcard function in Crate_Files. When this happens, make gets stuck
-	# trying to re-run this rule, without cargo touching the output files.
-	#
-	# To avoid this edge case, remove the two output files before invoking cargo build.
-	# This ensures that cargo build recreates them, with timestamps that satisfy make.
-	#
 	@rm -f $(Out_StaticLib) $(Out_Bindings)
 	cargo build --release
 

--- a/rtc_data_enclave/Makefile
+++ b/rtc_data_enclave/Makefile
@@ -32,8 +32,10 @@ CUSTOM_BUILD_PATH := build
 CUSTOM_LIBRARY_PATH := $(CUSTOM_BUILD_PATH)/lib
 CUSTOM_BIN_PATH := $(CUSTOM_BUILD_PATH)/bin
 
-# XXX: Is there a better way to express this source dependency on rtc_tenclave?
-Crate_Files := $(wildcard src/*.rs ../rtc_tenclave/src/*.rs)
+# Changes to these files trigger a rebuild of the enclave library (Out_StaticLib).
+# This includes the Rust source files of this crate, as well as the workspace crates we depend on.
+Crate_Files := $(shell find src ../rtc_tenclave/src ../rtc_types/src -name '*.rs')
+
 Out_StaticLib := $(CRATE_BUILD_PATH)/lib$(CRATE_LIB_NAME).a
 Out_Bindings := $(CODEGEN_PATH)/bindings.h
 

--- a/rtc_data_enclave/Makefile
+++ b/rtc_data_enclave/Makefile
@@ -86,17 +86,18 @@ $(CODEGEN_PATH):
 	mkdir -p $(CODEGEN_PATH)
 
 ####### Enclave Build ########
+#
+# XXX: Make sure cargo build refreshes the output files when this rule executes.
+#
+# Currently, it's possible for make to consider the output files out of date,
+# while cargo considers the build up to date, because cargo resolves with more nuance
+# than the crude wildcard function in Crate_Files. When this happens, make gets stuck
+# trying to re-run this rule, without cargo touching the output files.
+#
+# To avoid this edge case, remove the two output files before invoking cargo build.
+# This ensures that cargo build recreates them, with timestamps that satisfy make.
+#
 $(Out_StaticLib) $(Out_Bindings): $(Crate_Files)
-	# XXX: Make sure cargo build refreshes the output files when this rule executes.
-	#
-	# Currently, it's possible for make to consider the output files out of date,
-	# while cargo considers the build up to date, because cargo resolves with more nuance
-	# than the crude wildcard function in Crate_Files. When this happens, make gets stuck
-	# trying to re-run this rule, without cargo touching the output files.
-	#
-	# To avoid this edge case, remove the two output files before invoking cargo build.
-	# This ensures that cargo build recreates them, with timestamps that satisfy make.
-	#
 	@rm -f $(Out_StaticLib) $(Out_Bindings)
 	cargo build --release
 

--- a/rtc_exec_enclave/Makefile
+++ b/rtc_exec_enclave/Makefile
@@ -32,8 +32,10 @@ CUSTOM_BUILD_PATH := build
 CUSTOM_LIBRARY_PATH := $(CUSTOM_BUILD_PATH)/lib
 CUSTOM_BIN_PATH := $(CUSTOM_BUILD_PATH)/bin
 
-# XXX: Is there a better way to express this source dependency on rtc_tenclave?
-Crate_Files := $(wildcard src/*.rs ../rtc_tenclave/src/*.rs)
+# Changes to these files trigger a rebuild of the enclave library (Out_StaticLib).
+# This includes the Rust source files of this crate, as well as the workspace crates we depend on.
+Crate_Files := $(shell find src ../rtc_tenclave/src ../rtc_types/src -name '*.rs')
+
 Out_StaticLib := $(CRATE_BUILD_PATH)/lib$(CRATE_LIB_NAME).a
 Out_Bindings := $(CODEGEN_PATH)/bindings.h
 

--- a/rtc_exec_enclave/Makefile
+++ b/rtc_exec_enclave/Makefile
@@ -86,17 +86,18 @@ $(CODEGEN_PATH):
 	mkdir -p $(CODEGEN_PATH)
 
 ####### Enclave Build ########
+#
+# XXX: Make sure cargo build refreshes the output files when this rule executes.
+#
+# Currently, it's possible for make to consider the output files out of date,
+# while cargo considers the build up to date, because cargo resolves with more nuance
+# than the crude wildcard function in Crate_Files. When this happens, make gets stuck
+# trying to re-run this rule, without cargo touching the output files.
+#
+# To avoid this edge case, remove the two output files before invoking cargo build.
+# This ensures that cargo build recreates them, with timestamps that satisfy make.
+#
 $(Out_StaticLib) $(Out_Bindings): $(Crate_Files)
-	# XXX: Make sure cargo build refreshes the output files when this rule executes.
-	#
-	# Currently, it's possible for make to consider the output files out of date,
-	# while cargo considers the build up to date, because cargo resolves with more nuance
-	# than the crude wildcard function in Crate_Files. When this happens, make gets stuck
-	# trying to re-run this rule, without cargo touching the output files.
-	#
-	# To avoid this edge case, remove the two output files before invoking cargo build.
-	# This ensures that cargo build recreates them, with timestamps that satisfy make.
-	#
 	@rm -f $(Out_StaticLib) $(Out_Bindings)
 	cargo build --release
 


### PR DESCRIPTION
(This is a small drive-by fix, split from #87)