### PR TITLE
feat(DhSessions): add `with_acquire_*` helpers and `AcquireSessionError`

### DIFF
--- a/rtc_types/src/enclave_messages/errors.rs
+++ b/rtc_types/src/enclave_messages/errors.rs
@@ -1,0 +1,38 @@
+//! Errors related to enclave messages and sealing.
+
+use std::sync::PoisonError;
+
+use sgx_types::{sgx_enclave_id_t, sgx_status_t};
+use thiserror::Error;
+
+/// Failed to acquire session / protected channel.
+///
+/// See: `rtc_tenclave::dh::sessions::DhSessions`
+#[derive(Debug, PartialEq)] // core
+#[derive(Error)] // thiserror
+pub enum AcquireSessionError {
+    /// This should generally be treated as an unrecoverable error.
+    #[error("Channel mutex poisoned")]
+    ChannelMutexPoisoned, // see impl From<PoisonError>
+
+    #[error("No active session for enclave ID {0}")]
+    NoActiveSession(sgx_enclave_id_t),
+
+    #[error("SGX error: {0:?}")]
+    Sgx(sgx_status_t),
+}
+
+/// [`PoisonError`] contains a lock guard, which requires lifetime propagation,
+/// but we're not interested in using or recovering from a poisoned lock,
+/// so we discard the guard here.
+impl<_Guard> From<PoisonError<_Guard>> for AcquireSessionError {
+    fn from(_: PoisonError<_Guard>) -> Self {
+        AcquireSessionError::ChannelMutexPoisoned
+    }
+}
+
+impl From<sgx_status_t> for AcquireSessionError {
+    fn from(err: sgx_status_t) -> Self {
+        AcquireSessionError::Sgx(err)
+    }
+}

--- a/rtc_types/src/enclave_messages/mod.rs
+++ b/rtc_types/src/enclave_messages/mod.rs
@@ -19,6 +19,8 @@ pub struct EncryptedEnclaveMessage<const MESSAGE_SIZE: usize, const AAD_SIZE: us
     pub nonce: RecommendedAesGcmIv,
 }
 
+pub mod errors;
+
 /// XXX: Ignore this module to work around cbindgen generic type handling
 ///
 /// Issues:


### PR DESCRIPTION
This allows caller to use sessions without dealing with the more complicated mutex and guard APIs.

Precedes PR #87