### PR TITLE
feat(rtc_types): more enclave message work for set_access_key

### DIFF
--- a/cbindgen_enclaves.toml
+++ b/cbindgen_enclaves.toml
@@ -1,0 +1,31 @@
+# cbindgen config for the enclave bindings.h files
+#
+# These binding files should include all the types referenced by
+# the functions declared in our EDL files.
+#
+# Docs: <https://github.com/eqrion/cbindgen/blob/master/docs.md#cbindgentoml>
+
+language = "C"
+
+# No C standard imports for enclaves.
+no_includes = true
+
+[export]
+
+# Don't generate items for functions (sgx_edger8r will).
+item_types = [
+    "constants",
+    "globals",
+    "enums",
+    "structs",
+    "unions",
+    "typedefs",
+    "opaque",
+    # "functions",
+]
+
+# Also generate items for our local enclaves libraries.
+[parse]
+parse_deps = true
+include = ["rtc_types", "rtc_tenclave"]
+extra_bindings = ["rtc_types", "rtc_tenclave"]

--- a/cbindgen_enclaves.toml
+++ b/cbindgen_enclaves.toml
@@ -24,6 +24,10 @@ item_types = [
     # "functions",
 ]
 
+[enum]
+# Use qualified enum variant names: some of our enum types conflict, otherwise.
+rename_variants = "QualifiedScreamingSnakeCase"
+
 # Also generate items for our local enclaves libraries.
 [parse]
 parse_deps = true

--- a/codegen/auth_enclave/bindings.h
+++ b/codegen/auth_enclave/bindings.h
@@ -22,8 +22,8 @@
  * FFI safe result type that can be converted to and from a rust result.
  */
 typedef enum EcallResult_sgx_dh_msg1_t__sgx_status_t_Tag {
-  Ok_sgx_dh_msg1_t__sgx_status_t,
-  Err_sgx_dh_msg1_t__sgx_status_t,
+  ECALL_RESULT_SGX_DH_MSG1_T_SGX_STATUS_T_OK_SGX_DH_MSG1_T_SGX_STATUS_T,
+  ECALL_RESULT_SGX_DH_MSG1_T_SGX_STATUS_T_ERR_SGX_DH_MSG1_T_SGX_STATUS_T,
 } EcallResult_sgx_dh_msg1_t__sgx_status_t_Tag;
 
 typedef struct EcallResult_sgx_dh_msg1_t__sgx_status_t {
@@ -44,8 +44,8 @@ typedef struct EcallResult_sgx_dh_msg1_t__sgx_status_t SessionRequestResult;
  * FFI safe result type that can be converted to and from a rust result.
  */
 typedef enum EcallResult_sgx_dh_msg3_t__sgx_status_t_Tag {
-  Ok_sgx_dh_msg3_t__sgx_status_t,
-  Err_sgx_dh_msg3_t__sgx_status_t,
+  ECALL_RESULT_SGX_DH_MSG3_T_SGX_STATUS_T_OK_SGX_DH_MSG3_T_SGX_STATUS_T,
+  ECALL_RESULT_SGX_DH_MSG3_T_SGX_STATUS_T_ERR_SGX_DH_MSG3_T_SGX_STATUS_T,
 } EcallResult_sgx_dh_msg3_t__sgx_status_t_Tag;
 
 typedef struct EcallResult_sgx_dh_msg3_t__sgx_status_t {
@@ -63,10 +63,10 @@ typedef struct EcallResult_sgx_dh_msg3_t__sgx_status_t {
 typedef struct EcallResult_sgx_dh_msg3_t__sgx_status_t ExchangeReportResult;
 
 typedef enum CreateReportResult_Tag {
-  Success,
-  Sgx,
-  FailedToGetPublicKey,
-  FailedEncodePublicKey,
+  CREATE_REPORT_RESULT_SUCCESS,
+  CREATE_REPORT_RESULT_SGX,
+  CREATE_REPORT_RESULT_FAILED_TO_GET_PUBLIC_KEY,
+  CREATE_REPORT_RESULT_FAILED_ENCODE_PUBLIC_KEY,
 } CreateReportResult_Tag;
 
 typedef struct CreateReportResult {

--- a/codegen/data_enclave/bindings.h
+++ b/codegen/data_enclave/bindings.h
@@ -24,8 +24,8 @@ typedef struct DataUploadResponse {
 } DataUploadResponse;
 
 typedef enum CryptoError_Tag {
-  Rand,
-  Unknown,
+  CRYPTO_ERROR_RAND,
+  CRYPTO_ERROR_UNKNOWN,
 } CryptoError_Tag;
 
 typedef struct CryptoError {
@@ -38,9 +38,9 @@ typedef struct CryptoError {
 } CryptoError;
 
 typedef enum DataUploadError_Tag {
-  Validation,
-  Sealing,
-  Crypto,
+  DATA_UPLOAD_ERROR_VALIDATION,
+  DATA_UPLOAD_ERROR_SEALING,
+  DATA_UPLOAD_ERROR_CRYPTO,
 } DataUploadError_Tag;
 
 typedef struct DataUploadError {
@@ -59,8 +59,8 @@ typedef struct DataUploadError {
  * FFI safe result type that can be converted to and from a rust result.
  */
 typedef enum EcallResult_DataUploadResponse__DataUploadError_Tag {
-  Ok_DataUploadResponse__DataUploadError,
-  Err_DataUploadResponse__DataUploadError,
+  ECALL_RESULT_DATA_UPLOAD_RESPONSE_DATA_UPLOAD_ERROR_OK_DATA_UPLOAD_RESPONSE_DATA_UPLOAD_ERROR,
+  ECALL_RESULT_DATA_UPLOAD_RESPONSE_DATA_UPLOAD_ERROR_ERR_DATA_UPLOAD_RESPONSE_DATA_UPLOAD_ERROR,
 } EcallResult_DataUploadResponse__DataUploadError_Tag;
 
 typedef struct EcallResult_DataUploadResponse__DataUploadError {
@@ -86,8 +86,8 @@ typedef struct UploadMetadata {
  * FFI safe result type that can be converted to and from a rust result.
  */
 typedef enum EcallResult_sgx_dh_msg1_t__sgx_status_t_Tag {
-  Ok_sgx_dh_msg1_t__sgx_status_t,
-  Err_sgx_dh_msg1_t__sgx_status_t,
+  ECALL_RESULT_SGX_DH_MSG1_T_SGX_STATUS_T_OK_SGX_DH_MSG1_T_SGX_STATUS_T,
+  ECALL_RESULT_SGX_DH_MSG1_T_SGX_STATUS_T_ERR_SGX_DH_MSG1_T_SGX_STATUS_T,
 } EcallResult_sgx_dh_msg1_t__sgx_status_t_Tag;
 
 typedef struct EcallResult_sgx_dh_msg1_t__sgx_status_t {
@@ -108,8 +108,8 @@ typedef struct EcallResult_sgx_dh_msg1_t__sgx_status_t SessionRequestResult;
  * FFI safe result type that can be converted to and from a rust result.
  */
 typedef enum EcallResult_sgx_dh_msg3_t__sgx_status_t_Tag {
-  Ok_sgx_dh_msg3_t__sgx_status_t,
-  Err_sgx_dh_msg3_t__sgx_status_t,
+  ECALL_RESULT_SGX_DH_MSG3_T_SGX_STATUS_T_OK_SGX_DH_MSG3_T_SGX_STATUS_T,
+  ECALL_RESULT_SGX_DH_MSG3_T_SGX_STATUS_T_ERR_SGX_DH_MSG3_T_SGX_STATUS_T,
 } EcallResult_sgx_dh_msg3_t__sgx_status_t_Tag;
 
 typedef struct EcallResult_sgx_dh_msg3_t__sgx_status_t {
@@ -127,10 +127,10 @@ typedef struct EcallResult_sgx_dh_msg3_t__sgx_status_t {
 typedef struct EcallResult_sgx_dh_msg3_t__sgx_status_t ExchangeReportResult;
 
 typedef enum CreateReportResult_Tag {
-  Success,
-  Sgx,
-  FailedToGetPublicKey,
-  FailedEncodePublicKey,
+  CREATE_REPORT_RESULT_SUCCESS,
+  CREATE_REPORT_RESULT_SGX,
+  CREATE_REPORT_RESULT_FAILED_TO_GET_PUBLIC_KEY,
+  CREATE_REPORT_RESULT_FAILED_ENCODE_PUBLIC_KEY,
 } CreateReportResult_Tag;
 
 typedef struct CreateReportResult {

--- a/codegen/exec_enclave/bindings.h
+++ b/codegen/exec_enclave/bindings.h
@@ -22,8 +22,8 @@
  * FFI safe result type that can be converted to and from a rust result.
  */
 typedef enum EcallResult_sgx_dh_msg1_t__sgx_status_t_Tag {
-  Ok_sgx_dh_msg1_t__sgx_status_t,
-  Err_sgx_dh_msg1_t__sgx_status_t,
+  ECALL_RESULT_SGX_DH_MSG1_T_SGX_STATUS_T_OK_SGX_DH_MSG1_T_SGX_STATUS_T,
+  ECALL_RESULT_SGX_DH_MSG1_T_SGX_STATUS_T_ERR_SGX_DH_MSG1_T_SGX_STATUS_T,
 } EcallResult_sgx_dh_msg1_t__sgx_status_t_Tag;
 
 typedef struct EcallResult_sgx_dh_msg1_t__sgx_status_t {
@@ -44,8 +44,8 @@ typedef struct EcallResult_sgx_dh_msg1_t__sgx_status_t SessionRequestResult;
  * FFI safe result type that can be converted to and from a rust result.
  */
 typedef enum EcallResult_sgx_dh_msg3_t__sgx_status_t_Tag {
-  Ok_sgx_dh_msg3_t__sgx_status_t,
-  Err_sgx_dh_msg3_t__sgx_status_t,
+  ECALL_RESULT_SGX_DH_MSG3_T_SGX_STATUS_T_OK_SGX_DH_MSG3_T_SGX_STATUS_T,
+  ECALL_RESULT_SGX_DH_MSG3_T_SGX_STATUS_T_ERR_SGX_DH_MSG3_T_SGX_STATUS_T,
 } EcallResult_sgx_dh_msg3_t__sgx_status_t_Tag;
 
 typedef struct EcallResult_sgx_dh_msg3_t__sgx_status_t {
@@ -63,10 +63,10 @@ typedef struct EcallResult_sgx_dh_msg3_t__sgx_status_t {
 typedef struct EcallResult_sgx_dh_msg3_t__sgx_status_t ExchangeReportResult;
 
 typedef enum CreateReportResult_Tag {
-  Success,
-  Sgx,
-  FailedToGetPublicKey,
-  FailedEncodePublicKey,
+  CREATE_REPORT_RESULT_SUCCESS,
+  CREATE_REPORT_RESULT_SGX,
+  CREATE_REPORT_RESULT_FAILED_TO_GET_PUBLIC_KEY,
+  CREATE_REPORT_RESULT_FAILED_ENCODE_PUBLIC_KEY,
 } CreateReportResult_Tag;
 
 typedef struct CreateReportResult {

--- a/rtc_auth_enclave/build.rs
+++ b/rtc_auth_enclave/build.rs
@@ -1,13 +1,14 @@
 extern crate cbindgen;
 extern crate cc;
 
-use cbindgen::{Config, ExportConfig, ItemType};
 use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=rtc_auth.edl");
     println!("cargo:rerun-if-changed=src");
 
+    let cbindgen_config_file = "../cbindgen_enclaves.toml";
+    println!("cargo:rerun-if-changed={}", cbindgen_config_file);
     // Also rebuild if we delete bindings.h
     println!("cargo:rerun-if-changed=../codegen/auth_enclave/bindings.h");
 
@@ -16,29 +17,11 @@ fn main() {
     let _sgx_rust = String::from("/root/sgx-rust");
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
+    let cbindgen_config = cbindgen::Config::from_file(cbindgen_config_file).unwrap();
     cbindgen::Builder::new()
-        .with_config(Config {
-            export: ExportConfig {
-                item_types: vec![
-                    ItemType::Constants,
-                    ItemType::Globals,
-                    ItemType::Enums,
-                    ItemType::Structs,
-                    ItemType::Unions,
-                    ItemType::Typedefs,
-                    ItemType::OpaqueItems,
-                ],
-                ..Default::default()
-            },
-            ..Default::default()
-        })
+        .with_config(cbindgen_config)
         .with_crate(crate_dir)
         .with_std_types(false)
-        .with_language(cbindgen::Language::C)
-        .with_no_includes()
-        .with_parse_deps(true)
-        .with_parse_include(&["rtc_types", "rtc_tenclave"])
-        .with_parse_extra_bindings(&["rtc_types", "rtc_tenclave"])
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file("../codegen/auth_enclave/bindings.h");

--- a/rtc_exec_enclave/build.rs
+++ b/rtc_exec_enclave/build.rs
@@ -1,13 +1,14 @@
 extern crate cbindgen;
 extern crate cc;
 
-use cbindgen::{Config, ExportConfig, ItemType};
 use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=rtc_exec.edl");
     println!("cargo:rerun-if-changed=src");
 
+    let cbindgen_config_file = "../cbindgen_enclaves.toml";
+    println!("cargo:rerun-if-changed={}", cbindgen_config_file);
     // Also rebuild if we delete bindings.h
     println!("cargo:rerun-if-changed=../codegen/exec_enclave/bindings.h");
 
@@ -16,29 +17,11 @@ fn main() {
     let _sgx_rust = String::from("/root/sgx-rust");
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
+    let cbindgen_config = cbindgen::Config::from_file(cbindgen_config_file).unwrap();
     cbindgen::Builder::new()
-        .with_config(Config {
-            export: ExportConfig {
-                item_types: vec![
-                    ItemType::Constants,
-                    ItemType::Globals,
-                    ItemType::Enums,
-                    ItemType::Structs,
-                    ItemType::Unions,
-                    ItemType::Typedefs,
-                    ItemType::OpaqueItems,
-                ],
-                ..Default::default()
-            },
-            ..Default::default()
-        })
+        .with_config(cbindgen_config)
         .with_crate(crate_dir)
         .with_std_types(false)
-        .with_language(cbindgen::Language::C)
-        .with_no_includes()
-        .with_parse_deps(true)
-        .with_parse_include(&["rtc_types", "rtc_tenclave"])
-        .with_parse_extra_bindings(&["rtc_types", "rtc_tenclave"])
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file("../codegen/exec_enclave/bindings.h");

--- a/rtc_tenclave/src/dh/sealing.rs
+++ b/rtc_tenclave/src/dh/sealing.rs
@@ -2,11 +2,11 @@
 
 use core::mem::size_of;
 
-use rkyv::ser::serializers::{BufferSerializer, BufferSerializerError};
+use rkyv::ser::serializers::BufferSerializer;
 use rkyv::{Aligned, Archive, Deserialize, Infallible, Serialize};
 use rtc_types::byte_formats::rkyv_format;
+use rtc_types::enclave_messages::errors::SealingError;
 use rtc_types::enclave_messages::EncryptedEnclaveMessage;
-use sgx_types::sgx_status_t;
 
 use crate::dh::ProtectedChannel;
 
@@ -105,24 +105,6 @@ where
     A::Archived: Deserialize<A, Infallible>,
 {
     unsafe { rkyv_format::view_array::<A>(&sealed.aad) }
-}
-
-#[derive(Debug)]
-pub enum SealingError {
-    Rkyv(BufferSerializerError),
-    Sgx(sgx_status_t),
-}
-
-impl From<BufferSerializerError> for SealingError {
-    fn from(error: BufferSerializerError) -> Self {
-        SealingError::Rkyv(error)
-    }
-}
-
-impl From<sgx_status_t> for SealingError {
-    fn from(status: sgx_status_t) -> Self {
-        SealingError::Sgx(status)
-    }
 }
 
 #[cfg(test)]

--- a/rtc_types/src/enclave_messages/ffi_set_access_key.rs
+++ b/rtc_types/src/enclave_messages/ffi_set_access_key.rs
@@ -68,12 +68,12 @@ impl From<set_access_key::EncryptedRequest> for SetAccessKeyEncryptedRequest {
             nonce,
         }: set_access_key::EncryptedRequest,
     ) -> Self {
-        return SetAccessKeyEncryptedRequest {
+        SetAccessKeyEncryptedRequest {
             tag,
             ciphertext,
             aad,
             nonce,
-        };
+        }
     }
 }
 
@@ -86,12 +86,12 @@ impl From<SetAccessKeyEncryptedRequest> for set_access_key::EncryptedRequest {
             nonce,
         }: SetAccessKeyEncryptedRequest,
     ) -> Self {
-        return set_access_key::EncryptedRequest {
+        set_access_key::EncryptedRequest {
             tag,
             ciphertext,
             aad,
             nonce,
-        };
+        }
     }
 }
 
@@ -104,12 +104,12 @@ impl From<set_access_key::EncryptedResponse> for SetAccessKeyEncryptedResponse {
             nonce,
         }: set_access_key::EncryptedResponse,
     ) -> Self {
-        return SetAccessKeyEncryptedResponse {
+        SetAccessKeyEncryptedResponse {
             tag,
             ciphertext,
             aad,
             nonce,
-        };
+        }
     }
 }
 
@@ -122,12 +122,12 @@ impl From<SetAccessKeyEncryptedResponse> for set_access_key::EncryptedResponse {
             nonce,
         }: SetAccessKeyEncryptedResponse,
     ) -> Self {
-        return set_access_key::EncryptedResponse {
+        set_access_key::EncryptedResponse {
             tag,
             ciphertext,
             aad,
             nonce,
-        };
+        }
     }
 }
 

--- a/rtc_types/src/enclave_messages/set_access_key.rs
+++ b/rtc_types/src/enclave_messages/set_access_key.rs
@@ -2,6 +2,7 @@ use core::mem;
 
 use rkyv::{Archive, Deserialize, Serialize};
 
+use crate::enclave_messages::errors::SealingError;
 use crate::enclave_messages::{EncryptedEnclaveMessage, ARCHIVED_ENCLAVE_ID_SIZE};
 
 #[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Clone)]
@@ -31,6 +32,9 @@ pub const RESPONSE_SIZE: usize = mem::size_of::<ArchivedResponse>();
 
 // FFI type: EncryptedResponse
 pub type EncryptedResponse = EncryptedEnclaveMessage<RESPONSE_SIZE, 0>;
+
+// FFI type: SetAccessKeyResult
+pub type SetAccessKeyResult = Result<EncryptedResponse, SealingError>;
 
 // End FFI types
 


### PR DESCRIPTION
This adds `set_access_key::SetAccessKeyResult`, and makes `SealingError` FFI-compatible.

Precedes PR #87