### PR TITLE
feat(web service, data upload): pass the auth enclave ID to data enclave

### DIFF
--- a/rtc_data_service/src/auth_enclave_actor.rs
+++ b/rtc_data_service/src/auth_enclave_actor.rs
@@ -6,16 +6,9 @@
 use std::sync::Arc;
 
 use actix::prelude::*;
-use rtc_uenclave::{AttestationError, EnclaveConfig, RtcAuthEnclave};
+use rtc_uenclave::{EnclaveConfig, RtcAuthEnclave};
 
-#[derive(Default)]
-pub(crate) struct RequestAttestation;
-
-type RequestAttestationResult = Result<String, AttestationError>;
-
-impl Message for RequestAttestation {
-    type Result = RequestAttestationResult;
-}
+use crate::enclave_messages::{RequestAttestation, RequestAttestationResult};
 
 pub struct AuthEnclaveActor {
     enclave: Option<RtcAuthEnclave<Arc<EnclaveConfig>>>,

--- a/rtc_data_service/src/auth_enclave_actor.rs
+++ b/rtc_data_service/src/auth_enclave_actor.rs
@@ -7,8 +7,9 @@ use std::sync::Arc;
 
 use actix::prelude::*;
 use rtc_uenclave::{EnclaveConfig, RtcAuthEnclave};
+use sgx_types::sgx_enclave_id_t;
 
-use crate::enclave_messages::{RequestAttestation, RequestAttestationResult};
+use crate::enclave_messages::{GetEnclaveId, RequestAttestation, RequestAttestationResult};
 
 pub struct AuthEnclaveActor {
     enclave: Option<RtcAuthEnclave<Arc<EnclaveConfig>>>,
@@ -45,6 +46,14 @@ impl Actor for AuthEnclaveActor {
     fn started(&mut self, _ctx: &mut Self::Context) {
         self.enclave
             .replace(RtcAuthEnclave::init(self.config.clone()).expect("enclave to initialize"));
+    }
+}
+
+impl Handler<GetEnclaveId> for AuthEnclaveActor {
+    type Result = sgx_enclave_id_t;
+
+    fn handle(&mut self, _msg: GetEnclaveId, _ctx: &mut Self::Context) -> Self::Result {
+        self.get_enclave().geteid()
     }
 }
 

--- a/rtc_data_service/src/data_enclave_actor.rs
+++ b/rtc_data_service/src/data_enclave_actor.rs
@@ -6,16 +6,9 @@
 use std::sync::Arc;
 
 use actix::prelude::*;
-use rtc_uenclave::{AttestationError, EnclaveConfig, RtcDataEnclave};
+use rtc_uenclave::{EnclaveConfig, RtcDataEnclave};
 
-#[derive(Default)]
-pub(crate) struct RequestAttestation;
-
-type RequestAttestationResult = Result<String, AttestationError>;
-
-impl Message for RequestAttestation {
-    type Result = RequestAttestationResult;
-}
+use crate::enclave_messages::{RequestAttestation, RequestAttestationResult};
 
 pub struct DataEnclaveActor {
     enclave: Option<RtcDataEnclave<Arc<EnclaveConfig>>>,

--- a/rtc_data_service/src/data_enclave_actor.rs
+++ b/rtc_data_service/src/data_enclave_actor.rs
@@ -7,8 +7,9 @@ use std::sync::Arc;
 
 use actix::prelude::*;
 use rtc_uenclave::{EnclaveConfig, RtcDataEnclave};
+use sgx_types::sgx_enclave_id_t;
 
-use crate::enclave_messages::{RequestAttestation, RequestAttestationResult};
+use crate::enclave_messages::{GetEnclaveId, RequestAttestation, RequestAttestationResult};
 
 pub struct DataEnclaveActor {
     enclave: Option<RtcDataEnclave<Arc<EnclaveConfig>>>,
@@ -45,6 +46,14 @@ impl Actor for DataEnclaveActor {
     fn started(&mut self, _ctx: &mut Self::Context) {
         self.enclave
             .replace(RtcDataEnclave::init(self.config.clone()).expect("enclave to initialize"));
+    }
+}
+
+impl Handler<GetEnclaveId> for DataEnclaveActor {
+    type Result = sgx_enclave_id_t;
+
+    fn handle(&mut self, _msg: GetEnclaveId, _ctx: &mut Self::Context) -> Self::Result {
+        self.get_enclave().geteid()
     }
 }
 

--- a/rtc_data_service/src/data_upload/message.rs
+++ b/rtc_data_service/src/data_upload/message.rs
@@ -3,9 +3,13 @@ use rtc_types::{DataUploadError, DataUploadResponse, EcallError, UploadMetadata}
 
 use crate::data_enclave_actor::DataEnclaveActor;
 
-pub struct DataUploadMessage {
+pub struct DataUploadRequest {
     pub metadata: UploadMetadata,
     pub payload: Box<[u8]>,
+}
+
+pub struct DataUploadMessage {
+    pub request: DataUploadRequest,
 }
 
 impl Message for DataUploadMessage {
@@ -17,6 +21,7 @@ impl Handler<DataUploadMessage> for DataEnclaveActor {
     type Result = <DataUploadMessage as Message>::Result;
 
     fn handle(&mut self, msg: DataUploadMessage, _ctx: &mut Self::Context) -> Self::Result {
-        self.get_enclave().upload_data(&msg.payload, msg.metadata)
+        self.get_enclave()
+            .upload_data(&msg.request.payload, msg.request.metadata)
     }
 }

--- a/rtc_data_service/src/data_upload/message.rs
+++ b/rtc_data_service/src/data_upload/message.rs
@@ -1,5 +1,6 @@
 use actix::{Handler, Message};
 use rtc_types::{DataUploadError, DataUploadResponse, EcallError, UploadMetadata};
+use sgx_types::sgx_enclave_id_t;
 
 use crate::data_enclave_actor::DataEnclaveActor;
 
@@ -11,11 +12,12 @@ pub struct DataUploadRequest {
     pub payload: Box<[u8]>,
 }
 
-/// [`Message`]: Process a sealed [`DataUploadRequest`].
+/// [`Message`]: Process a [`DataUploadRequest`] sealed for [`auth_enclave_id`].
 /// Return a sealed [`DataUploadResponse`].
 ///
 /// See: [`rtc_uenclave::enclaves::rtc_data::upload_data`]
 pub struct DataUploadMessage {
+    pub auth_enclave_id: sgx_enclave_id_t,
     pub request: DataUploadRequest,
 }
 

--- a/rtc_data_service/src/data_upload/message.rs
+++ b/rtc_data_service/src/data_upload/message.rs
@@ -3,11 +3,18 @@ use rtc_types::{DataUploadError, DataUploadResponse, EcallError, UploadMetadata}
 
 use crate::data_enclave_actor::DataEnclaveActor;
 
+/// Sealed request from a client to upload a new dataset.
+///
+/// See: [`crate::data_upload::service::models::RequestBody`]
 pub struct DataUploadRequest {
     pub metadata: UploadMetadata,
     pub payload: Box<[u8]>,
 }
 
+/// [`Message`]: Process a sealed [`DataUploadRequest`].
+/// Return a sealed [`DataUploadResponse`].
+///
+/// See: [`rtc_uenclave::enclaves::rtc_data::upload_data`]
 pub struct DataUploadMessage {
     pub request: DataUploadRequest,
 }

--- a/rtc_data_service/src/data_upload/service.rs
+++ b/rtc_data_service/src/data_upload/service.rs
@@ -20,13 +20,13 @@ use crate::merge_error::*;
 #[post("/data/uploads")]
 pub async fn upload_file(
     req_body: web::Json<RequestBody>,
-    enclave: web::Data<Addr<DataEnclaveActor>>,
+    data_enclave: web::Data<Addr<DataEnclaveActor>>,
 ) -> actix_web::Result<web::Json<ResponseBody>> {
     let request: DataUploadRequest = req_body.0.try_into()?;
     let message = DataUploadMessage { request };
 
     let result: Result<DataUploadResponse, MergedError<EcallError<DataUploadError>, MailboxError>> =
-        enclave.send(message).await.merge_err();
+        data_enclave.send(message).await.merge_err();
 
     match result {
         Ok(resp) => Ok(web::Json(resp.into())),

--- a/rtc_data_service/src/enclave_messages.rs
+++ b/rtc_data_service/src/enclave_messages.rs
@@ -3,6 +3,10 @@
 use actix::Message;
 use rtc_uenclave::AttestationError;
 
+/// [`Message`]: Request enclave attestation.
+/// Return JWT with quote and enclave data.
+///
+/// See: [`rtc_uenclave::rtc_enclave::dcap_attestation_azure`]
 #[derive(Default)]
 pub(crate) struct RequestAttestation;
 

--- a/rtc_data_service/src/enclave_messages.rs
+++ b/rtc_data_service/src/enclave_messages.rs
@@ -1,0 +1,13 @@
+//! Common message types for the enclave actors.
+
+use actix::Message;
+use rtc_uenclave::AttestationError;
+
+#[derive(Default)]
+pub(crate) struct RequestAttestation;
+
+pub(crate) type RequestAttestationResult = Result<String, AttestationError>;
+
+impl Message for RequestAttestation {
+    type Result = RequestAttestationResult;
+}

--- a/rtc_data_service/src/enclave_messages.rs
+++ b/rtc_data_service/src/enclave_messages.rs
@@ -2,6 +2,18 @@
 
 use actix::Message;
 use rtc_uenclave::AttestationError;
+use sgx_types::sgx_enclave_id_t;
+
+/// [`Message`]: Get the enclave's ID.
+/// Return [`sgx_enclave_id_t`].
+///
+/// See: [`rtc_uenclave::rtc_enclave::geteid`]
+#[derive(Default)]
+pub(crate) struct GetEnclaveId;
+
+impl Message for GetEnclaveId {
+    type Result = sgx_enclave_id_t;
+}
 
 /// [`Message`]: Request enclave attestation.
 /// Return JWT with quote and enclave data.

--- a/rtc_data_service/src/exec_enclave_actor.rs
+++ b/rtc_data_service/src/exec_enclave_actor.rs
@@ -6,16 +6,9 @@
 use std::sync::Arc;
 
 use actix::prelude::*;
-use rtc_uenclave::{AttestationError, EnclaveConfig, RtcExecEnclave};
+use rtc_uenclave::{EnclaveConfig, RtcExecEnclave};
 
-#[derive(Default)]
-pub(crate) struct RequestAttestation;
-
-type RequestAttestationResult = Result<String, AttestationError>;
-
-impl Message for RequestAttestation {
-    type Result = RequestAttestationResult;
-}
+use crate::enclave_messages::{RequestAttestation, RequestAttestationResult};
 
 pub struct ExecEnclaveActor {
     enclave: Option<RtcExecEnclave<Arc<EnclaveConfig>>>,

--- a/rtc_data_service/src/exec_enclave_actor.rs
+++ b/rtc_data_service/src/exec_enclave_actor.rs
@@ -7,8 +7,9 @@ use std::sync::Arc;
 
 use actix::prelude::*;
 use rtc_uenclave::{EnclaveConfig, RtcExecEnclave};
+use sgx_types::sgx_enclave_id_t;
 
-use crate::enclave_messages::{RequestAttestation, RequestAttestationResult};
+use crate::enclave_messages::{GetEnclaveId, RequestAttestation, RequestAttestationResult};
 
 pub struct ExecEnclaveActor {
     enclave: Option<RtcExecEnclave<Arc<EnclaveConfig>>>,
@@ -45,6 +46,14 @@ impl Actor for ExecEnclaveActor {
     fn started(&mut self, _ctx: &mut Self::Context) {
         self.enclave
             .replace(RtcExecEnclave::init(self.config.clone()).expect("enclave to initialize"));
+    }
+}
+
+impl Handler<GetEnclaveId> for ExecEnclaveActor {
+    type Result = sgx_enclave_id_t;
+
+    fn handle(&mut self, _msg: GetEnclaveId, _ctx: &mut Self::Context) -> Self::Result {
+        self.get_enclave().geteid()
     }
 }
 

--- a/rtc_data_service/src/handlers.rs
+++ b/rtc_data_service/src/handlers.rs
@@ -5,9 +5,9 @@ use models::Status;
 
 use crate::auth_enclave_actor::AuthEnclaveActor;
 use crate::data_enclave_actor::DataEnclaveActor;
+use crate::enclave_messages::RequestAttestation;
 use crate::exec_enclave_actor::ExecEnclaveActor;
 use crate::merge_error::*;
-use crate::{auth_enclave_actor, data_enclave_actor, exec_enclave_actor};
 
 pub async fn server_status(_req: HttpRequest) -> HttpResponse {
     HttpResponse::Ok().json(Status {
@@ -21,7 +21,7 @@ pub async fn auth_enclave_attestation(
     enclave: web::Data<Addr<AuthEnclaveActor>>,
 ) -> actix_web::Result<String> {
     let jwt = enclave
-        .send(auth_enclave_actor::RequestAttestation::default())
+        .send(RequestAttestation::default())
         .await
         .merge_err();
     dbg!(&jwt);
@@ -39,7 +39,7 @@ pub async fn data_enclave_attestation(
     enclave: web::Data<Addr<DataEnclaveActor>>,
 ) -> actix_web::Result<String> {
     let jwt = enclave
-        .send(data_enclave_actor::RequestAttestation::default())
+        .send(RequestAttestation::default())
         .await
         .merge_err();
     dbg!(&jwt);
@@ -57,7 +57,7 @@ pub async fn exec_enclave_attestation(
     enclave: web::Data<Addr<ExecEnclaveActor>>,
 ) -> actix_web::Result<String> {
     let jwt = enclave
-        .send(exec_enclave_actor::RequestAttestation::default())
+        .send(RequestAttestation::default())
         .await
         .merge_err();
     dbg!(&jwt);

--- a/rtc_data_service/src/lib.rs
+++ b/rtc_data_service/src/lib.rs
@@ -7,6 +7,7 @@ pub mod app_config;
 pub mod auth_enclave_actor;
 pub mod data_enclave_actor;
 pub mod data_upload;
+mod enclave_messages;
 pub mod exec;
 pub mod exec_enclave_actor;
 pub mod exec_token;


### PR DESCRIPTION
This changes the data upload flow so that the handler passes the auth enclave's ID to the data enclave, alongside the data upload request. (The data enclave needs this to establish a protected channel with the auth enclave.)

- Supports issue #39

- Follows PR #87 